### PR TITLE
Add development SMS catcher package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# laravel-sms-catcher
+# Laravel SMS Catcher
+
+A development-only Laravel package that captures SMS notifications and displays them in a beautiful, phone-inspired inbox – think Mailpit, but for your `sms` notification channel.
+
+## Installation
+
+Require the package in your application as a dev dependency:
+
+```bash
+composer require --dev acme/laravel-sms-catcher
+```
+
+The package is auto-discovered by Laravel, but you can manually register the service provider if you have discovery disabled:
+
+```php
+// config/app.php
+'providers' => [
+    // ...
+    SmsCatcher\SmsCatcherServiceProvider::class,
+];
+```
+
+## Configuration
+
+By default the dashboard is only enabled when your application is running in the `local` environment or when `APP_DEBUG=true`. You can override this behaviour via the `SMS_CATCHER_ENABLED` environment variable.
+
+Publish the configuration file if you would like to customise the dashboard path or storage location:
+
+```bash
+php artisan vendor:publish --tag=sms-catcher-config
+```
+
+This will create `config/sms-catcher.php` with the following options:
+
+- `enabled`: Toggle the catcher on/off.
+- `route.prefix`: URL prefix for the dashboard (defaults to `/sms-catcher`).
+- `route.middleware`: Middleware stack wrapping the dashboard routes.
+- `storage_path`: File that stores captured messages.
+
+## Usage
+
+Trigger any Laravel notification that uses the `sms` channel and the payload will be recorded automatically. Visit the dashboard (default at `http://your-app.test/sms-catcher`) to see the inbox:
+
+- Inbox view summarises each message.
+- Click a message to view details and a phone-style preview.
+- Clear individual messages or wipe the entire inbox.
+
+Messages are stored as JSON within your application's storage folder (`storage/framework/sms-catcher.json`). The file is safe to delete; it will be recreated as new messages arrive.
+
+> **Note**: The catcher inspects notifications by invoking their `toSms` method. Ensure your notifications implement this method and return either a string, array, or object containing the text body.
+
+## Security
+
+This package is intended for local development only. Do not enable it in production environments.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "acme/laravel-sms-catcher",
+    "description": "A development-only inbox for inspecting Laravel SMS notifications.",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.1",
+        "illuminate/support": "^10.0|^11.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^8.0|^9.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "SmsCatcher\\": "src/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "SmsCatcher\\SmsCatcherServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/config/sms-catcher.php
+++ b/config/sms-catcher.php
@@ -1,0 +1,41 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Enable SMS Catcher
+    |--------------------------------------------------------------------------
+    |
+    | By default the sms catcher is only active when the application is running
+    | in the local environment or when APP_DEBUG is true. You can explicitly
+    | enable or disable it via the SMS_CATCHER_ENABLED environment variable.
+    */
+
+    'enabled' => env('SMS_CATCHER_ENABLED', env('APP_ENV') === 'local' || env('APP_DEBUG', false)),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Route configuration
+    |--------------------------------------------------------------------------
+    |
+    | Customize the prefix and middleware that wrap the sms catcher dashboard.
+    | The dashboard is intentionally registered inside the web middleware group
+    | so sessions and CSRF protection are available.
+    */
+
+    'route' => [
+        'prefix' => 'sms-catcher',
+        'middleware' => ['web'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Storage file
+    |--------------------------------------------------------------------------
+    |
+    | Messages are persisted to a lightweight JSON file inside the application's
+    | storage directory. You may change the location if required.
+    */
+
+    'storage_path' => storage_path('framework/sms-catcher.json'),
+];

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,0 +1,33 @@
+@extends('sms-catcher::layout')
+
+@section('content')
+    <div class="panel">
+        <div class="panel-header">
+            <div>
+                <strong>{{ $messages->count() }} message{{ $messages->count() === 1 ? '' : 's' }}</strong>
+                <div class="meta">Only available in local/dev environments</div>
+            </div>
+            <div class="actions">
+                <form method="POST" action="{{ route('sms-catcher.clear') }}">
+                    @csrf
+                    @method('DELETE')
+                    <button class="btn" type="submit">Clear inbox</button>
+                </form>
+            </div>
+        </div>
+        <div class="message-list">
+            @forelse($messages as $message)
+                <a href="{{ route('sms-catcher.show', $message['id']) }}" class="message">
+                    <div><strong>{{ $message['to'] }}</strong></div>
+                    <div>{{ \Illuminate\Support\Str::limit($message['body'], 120) }}</div>
+                    <small>{{ \Carbon\Carbon::parse($message['timestamp'])->diffForHumans() }}</small>
+                </a>
+            @empty
+                <div class="empty">
+                    <p>No SMS notifications have been captured yet.</p>
+                    <p>Trigger a notification using the <code>sms</code> channel to see it appear here.</p>
+                </div>
+            @endforelse
+        </div>
+    </div>
+@endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>SMS Catcher</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f7fafc;
+            --panel: #ffffff;
+            --border: #e2e8f0;
+            --accent: #38bdf8;
+            --text: #1a202c;
+            --muted: #4a5568;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: var(--bg);
+            color: var(--text);
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        h1 {
+            font-size: 1.75rem;
+            margin-bottom: 1.5rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        h1 span {
+            background: var(--accent);
+            color: white;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.5rem;
+            font-size: 0.9rem;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+            gap: 1.5rem;
+        }
+
+        .panel {
+            background: var(--panel);
+            border-radius: 1rem;
+            border: 1px solid var(--border);
+            box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+            overflow: hidden;
+        }
+
+        .panel-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .message-list {
+            max-height: 540px;
+            overflow-y: auto;
+        }
+
+        .message {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid var(--border);
+            text-decoration: none;
+            color: inherit;
+            transition: background 0.15s ease;
+        }
+
+        .message:hover {
+            background: rgba(56, 189, 248, 0.08);
+        }
+
+        .message:last-child {
+            border-bottom: none;
+        }
+
+        .message small {
+            color: var(--muted);
+        }
+
+        .phone-shell {
+            width: 280px;
+            margin: 2rem auto;
+            border: 12px solid #111827;
+            border-radius: 36px;
+            padding: 1.5rem 1rem;
+            background: linear-gradient(145deg, #0f172a, #1e293b);
+            box-shadow: 0 20px 45px rgba(15, 23, 42, 0.4);
+        }
+
+        .phone-screen {
+            background: #0f172a;
+            border-radius: 24px;
+            padding: 1.5rem 1rem;
+            min-height: 360px;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            color: #e2e8f0;
+        }
+
+        .bubble {
+            max-width: 80%;
+            padding: 0.75rem 1rem;
+            border-radius: 18px;
+            background: rgba(148, 163, 184, 0.25);
+            align-self: flex-start;
+            line-height: 1.4;
+        }
+
+        .meta {
+            color: var(--muted);
+            font-size: 0.85rem;
+        }
+
+        .actions {
+            display: flex;
+            gap: 0.75rem;
+        }
+
+        .btn {
+            border: none;
+            background: rgba(148, 163, 184, 0.25);
+            color: inherit;
+            padding: 0.5rem 0.85rem;
+            border-radius: 0.5rem;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease;
+            font-size: 0.9rem;
+        }
+
+        .btn:hover {
+            background: rgba(56, 189, 248, 0.25);
+            transform: translateY(-1px);
+        }
+
+        .empty {
+            padding: 2rem;
+            text-align: center;
+            color: var(--muted);
+        }
+
+        @media (max-width: 960px) {
+            .grid {
+                grid-template-columns: 1fr;
+            }
+
+            .phone-shell {
+                width: 220px;
+                margin: 1.5rem auto;
+            }
+        }
+    </style>
+    @stack('head')
+</head>
+<body>
+<div class="container">
+    <h1>
+        SMS Catcher
+        <span>dev</span>
+    </h1>
+
+    @yield('content')
+</div>
+</body>
+</html>

--- a/resources/views/show.blade.php
+++ b/resources/views/show.blade.php
@@ -1,0 +1,54 @@
+@extends('sms-catcher::layout')
+
+@section('content')
+    <div class="grid">
+        <div class="panel">
+            <div class="panel-header">
+                <div>
+                    <strong>Message details</strong>
+                    <div class="meta">Sent {{ \Carbon\Carbon::parse($message['timestamp'])->toDayDateTimeString() }}</div>
+                </div>
+                <div class="actions">
+                    <form method="POST" action="{{ route('sms-catcher.destroy', $message['id']) }}">
+                        @csrf
+                        @method('DELETE')
+                        <button class="btn" type="submit">Delete</button>
+                    </form>
+                    <a class="btn" href="{{ route('sms-catcher.index') }}">Back</a>
+                </div>
+            </div>
+            <div style="padding: 1.5rem; display: grid; gap: 1rem;">
+                <div>
+                    <div class="meta">To</div>
+                    <div><strong>{{ $message['to'] }}</strong></div>
+                </div>
+                @if($message['from'])
+                    <div>
+                        <div class="meta">From</div>
+                        <div>{{ $message['from'] }}</div>
+                    </div>
+                @endif
+                <div>
+                    <div class="meta">Notification</div>
+                    <div><code>{{ $message['notification'] }}</code></div>
+                </div>
+                @if(!empty($message['extra']))
+                    <div>
+                        <div class="meta">Extra payload</div>
+                        <pre style="background: rgba(148,163,184,0.12); padding: 1rem; border-radius: 0.75rem; overflow-x: auto;">{{ json_encode($message['extra'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+                    </div>
+                @endif
+            </div>
+        </div>
+        <div class="panel">
+            <div class="panel-header">
+                <strong>Preview</strong>
+            </div>
+            <div class="phone-shell">
+                <div class="phone-screen">
+                    <div class="bubble">{!! nl2br(e($message['body'])) !!}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/src/Http/Controllers/SmsMessageController.php
+++ b/src/Http/Controllers/SmsMessageController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SmsCatcher\Http\Controllers;
+
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Controller;
+use SmsCatcher\Storage\MessageRepository;
+
+class SmsMessageController extends Controller
+{
+    public function __construct(protected MessageRepository $repository)
+    {
+    }
+
+    public function index(): View|Factory
+    {
+        return view('sms-catcher::index', [
+            'messages' => $this->repository->all(),
+        ]);
+    }
+
+    public function show(string $id): View|Factory
+    {
+        $message = $this->repository->find($id);
+
+        abort_if($message === null, 404);
+
+        return view('sms-catcher::show', [
+            'message' => $message,
+        ]);
+    }
+
+    public function destroy(string $id): RedirectResponse
+    {
+        $this->repository->delete($id);
+
+        return redirect()->route('sms-catcher.index');
+    }
+
+    public function clear(): RedirectResponse
+    {
+        $this->repository->clear();
+
+        return redirect()->route('sms-catcher.index');
+    }
+}

--- a/src/SmsCatcherServiceProvider.php
+++ b/src/SmsCatcherServiceProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SmsCatcher;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use SmsCatcher\Http\Controllers\SmsMessageController;
+use SmsCatcher\Storage\MessageRepository;
+
+class SmsCatcherServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/sms-catcher.php', 'sms-catcher');
+
+        $this->app->singleton(MessageRepository::class, function ($app) {
+            return new MessageRepository(config('sms-catcher.storage_path'));
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(Dispatcher $events): void
+    {
+        $this->publishes([
+            __DIR__ . '/../config/sms-catcher.php' => config_path('sms-catcher.php'),
+        ], 'sms-catcher-config');
+
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'sms-catcher');
+
+        if (!config('sms-catcher.enabled')) {
+            return;
+        }
+
+        $this->registerRoutes();
+        $this->registerListeners($events);
+    }
+
+    protected function registerRoutes(): void
+    {
+        Route::group(config('sms-catcher.route'), function () {
+            Route::get('/', [SmsMessageController::class, 'index'])->name('sms-catcher.index');
+            Route::get('/messages/{id}', [SmsMessageController::class, 'show'])->name('sms-catcher.show');
+            Route::delete('/messages/{id}', [SmsMessageController::class, 'destroy'])->name('sms-catcher.destroy');
+            Route::delete('/', [SmsMessageController::class, 'clear'])->name('sms-catcher.clear');
+        });
+    }
+
+    protected function registerListeners(Dispatcher $events): void
+    {
+        $events->listen(NotificationSending::class, function (NotificationSending $event) {
+            if ($event->channel !== 'sms') {
+                return;
+            }
+
+            /** @var MessageRepository $repository */
+            $repository = $this->app->make(MessageRepository::class);
+            $repository->storeFromEvent($event);
+        });
+    }
+}

--- a/src/Storage/MessageRepository.php
+++ b/src/Storage/MessageRepository.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace SmsCatcher\Storage;
+
+use Illuminate\Notifications\Events\NotificationSending;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use JsonException;
+
+class MessageRepository
+{
+    public function __construct(protected string $path)
+    {
+        $directory = dirname($this->path);
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function all(): Collection
+    {
+        $messages = $this->read();
+
+        return collect($messages)->sortByDesc('timestamp')->values();
+    }
+
+    public function find(string $id): ?array
+    {
+        foreach ($this->read() as $message) {
+            if ($message['id'] === $id) {
+                return $message;
+            }
+        }
+
+        return null;
+    }
+
+    public function delete(string $id): void
+    {
+        $messages = array_values(array_filter($this->read(), fn ($message) => $message['id'] !== $id));
+        $this->write($messages);
+    }
+
+    public function clear(): void
+    {
+        $this->write([]);
+    }
+
+    public function storeFromEvent(NotificationSending $event): void
+    {
+        $message = $this->resolveMessage($event);
+
+        if ($message === null) {
+            return;
+        }
+
+        $messages = $this->read();
+        $messages[] = $message;
+
+        $this->write($messages);
+    }
+
+    protected function resolveMessage(NotificationSending $event): ?array
+    {
+        $notification = $event->notification;
+
+        if (!method_exists($notification, 'toSms')) {
+            return null;
+        }
+
+        $smsMessage = $notification->toSms($event->notifiable);
+
+        $content = $this->normalizeMessage($smsMessage);
+
+        if ($content === null) {
+            return null;
+        }
+
+        return [
+            'id' => (string) Str::uuid(),
+            'to' => $this->resolveRecipient($event),
+            'from' => $content['from'] ?? null,
+            'body' => $content['body'],
+            'notification' => $notification::class,
+            'timestamp' => now()->toIso8601String(),
+            'extra' => $content['extra'] ?? [],
+        ];
+    }
+
+    protected function resolveRecipient(NotificationSending $event): string
+    {
+        $notifiable = $event->notifiable;
+
+        if (method_exists($notifiable, 'routeNotificationFor')) {
+            $phone = $notifiable->routeNotificationFor('sms');
+            if ($phone !== null) {
+                return $phone;
+            }
+        }
+
+        return (string) ($notifiable->phone ?? $notifiable->phone_number ?? 'unknown');
+    }
+
+    protected function normalizeMessage(mixed $smsMessage): ?array
+    {
+        if (is_string($smsMessage)) {
+            return ['body' => $smsMessage];
+        }
+
+        if (is_object($smsMessage) && method_exists($smsMessage, '__toString')) {
+            return ['body' => (string) $smsMessage];
+        }
+
+        if (is_array($smsMessage)) {
+            $body = $smsMessage['body'] ?? $smsMessage['text'] ?? null;
+
+            if ($body === null) {
+                return null;
+            }
+
+            $normalized = ['body' => $body];
+
+            if (isset($smsMessage['from'])) {
+                $normalized['from'] = $smsMessage['from'];
+            }
+
+            $normalized['extra'] = collect($smsMessage)->except(['body', 'text', 'from'])->toArray();
+
+            return $normalized;
+        }
+
+        if (is_object($smsMessage)) {
+            $body = $smsMessage->body ?? $smsMessage->text ?? null;
+
+            if ($body === null) {
+                return null;
+            }
+
+            $normalized = ['body' => $body];
+
+            if (isset($smsMessage->from)) {
+                $normalized['from'] = $smsMessage->from;
+            }
+
+            $extra = collect(get_object_vars($smsMessage))->except(['body', 'text', 'from'])->toArray();
+            if (!empty($extra)) {
+                $normalized['extra'] = $extra;
+            }
+
+            return $normalized;
+        }
+
+        return null;
+    }
+
+    protected function read(): array
+    {
+        if (!file_exists($this->path)) {
+            return [];
+        }
+
+        try {
+            $contents = file_get_contents($this->path);
+            if ($contents === false || $contents === '') {
+                return [];
+            }
+
+            return json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return [];
+        }
+    }
+
+    protected function write(array $messages): void
+    {
+        file_put_contents($this->path, json_encode($messages, JSON_PRETTY_PRINT));
+    }
+}


### PR DESCRIPTION
## Summary
- add a development-only Laravel package that captures sms notifications and stores them locally
- expose a dashboard with inbox and phone-style preview for captured messages
- provide configuration, routing, and storage glue to activate the catcher in local environments

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_69009194abcc832e90b6b3ccb00b3083