### PR TITLE
Mark SMS messages as read when viewed

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -87,10 +87,16 @@ function updateMessageList(messages) {
                 ? `<span class="message-from">From ${escapeHtml(message.from)}</span>`
                 : '';
 
+            const unreadClass = message.read_at ? '' : 'message-unread';
+            const unreadDot = message.read_at ? '' : '<span class="unread-dot" aria-label="Unread message"></span>';
+
             html += `
-                <a href="${showRouteBase}${message.id}" class="message">
+                <a href="${showRouteBase}${message.id}" class="message ${unreadClass}">
                     <div class="message-header">
-                        <strong>${escapeHtml(message.to)}</strong>
+                        <div class="message-title">
+                            ${unreadDot}
+                            <strong>${escapeHtml(message.to)}</strong>
+                        </div>
                         ${fromHtml}
                     </div>
                     <div>${linkifyText(limitedBody)}</div>
@@ -201,9 +207,14 @@ window.addEventListener('beforeunload', function() {
         </div>
         <div class="message-list">
             @forelse($messages as $message)
-                <a href="{{ route('sms-catcher.show', $message['id']) }}" class="message">
+                <a href="{{ route('sms-catcher.show', $message['id']) }}" class="message {{ empty($message['read_at']) ? 'message-unread' : '' }}">
                     <div class="message-header">
-                        <strong>{{ $message['to'] }}</strong>
+                        <div class="message-title">
+                            @if(empty($message['read_at']))
+                                <span class="unread-dot" aria-label="Unread message"></span>
+                            @endif
+                            <strong>{{ $message['to'] }}</strong>
+                        </div>
                         @if(!empty($message['from']))
                             <span class="message-from">From {{ $message['from'] }}</span>
                         @endif

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -170,6 +170,22 @@
             flex-wrap: wrap;
         }
 
+        .message-title {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .unread-dot {
+            width: 0.5rem;
+            height: 0.5rem;
+            border-radius: 999px;
+            background: var(--accent);
+            display: inline-block;
+            box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.15);
+            flex-shrink: 0;
+        }
+
         .message-from {
             color: var(--muted);
             font-size: 0.85rem;

--- a/src/Http/Controllers/SmsMessageController.php
+++ b/src/Http/Controllers/SmsMessageController.php
@@ -30,7 +30,7 @@ class SmsMessageController extends Controller
 
     public function show(string $id): View|Factory
     {
-        $message = $this->repository->find($id);
+        $message = $this->repository->markAsRead($id);
 
         abort_if($message === null, 404);
 

--- a/src/Storage/MessageRepository.php
+++ b/src/Storage/MessageRepository.php
@@ -45,6 +45,34 @@ class MessageRepository
         return null;
     }
 
+    public function markAsRead(string $id): ?array
+    {
+        $messages = $this->read();
+        $updatedMessage = null;
+
+        foreach ($messages as $index => $message) {
+            if ($message['id'] !== $id) {
+                continue;
+            }
+
+            if (empty($message['read_at'])) {
+                $message['read_at'] = now()->toIso8601String();
+                $messages[$index] = $message;
+            }
+
+            $updatedMessage = $message;
+            break;
+        }
+
+        if ($updatedMessage === null) {
+            return null;
+        }
+
+        $this->write($messages);
+
+        return $updatedMessage;
+    }
+
     public function delete(string $id): void
     {
         $messages = array_values(array_filter($this->read(), fn ($message) => $message['id'] !== $id));
@@ -93,6 +121,7 @@ class MessageRepository
             'body' => $content['body'],
             'notification' => $notification::class,
             'timestamp' => now()->toIso8601String(),
+            'read_at' => null,
             'extra' => $content['extra'] ?? [],
         ];
     }


### PR DESCRIPTION
### Motivation
- Persist read state so messages can be tracked as "read" after the user opens them. 
- Store the state in the JSON message store so read status survives server restarts. 
- Give users a subtle visual cue for unread messages in the inbox. 
- Ensure auto-update and the list view reflect the read state.

### Description
- Add a `read_at` field to stored messages and initialize it to `null` when messages are created in `MessageRepository`. 
- Implement `markAsRead(string $id)` in `MessageRepository` to set `read_at` and persist the JSON file. 
- Update the `SmsMessageController::show` flow to call `markAsRead()` instead of `find()` so opening the detail page marks a message read. 
- Add UI/CSS/JS to show an unread indicator (small blue dot) and a `message-unread` class in both server-rendered and client-updated list views (`resources/views/layout.blade.php` and `resources/views/index.blade.php`).

### Testing
- No unit or integration test suite was executed against these changes. 
- A headless browser preview attempt using Playwright to capture a screenshot of the unread indicator was run and the Chromium process crashed (SIGSEGV), so the visual check did not complete successfully. 
- Manual static HTML preview was created locally to sanity-check the UI markup (not an automated test). 
- All code changes were linted/compiled by PHP file inspection during development, with no runtime test suite results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f6767d46c832ea9ae2d726b9fb47b)